### PR TITLE
Update docker image bases

### DIFF
--- a/php/.docker/Alpine.Dockerfile
+++ b/php/.docker/Alpine.Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 WORKDIR /var/www/html
 
 # Install composer dependencies
-COPY --from=composer:1.10.6 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
 COPY composer.json composer.lock ./
 
 RUN composer install \
@@ -14,24 +14,27 @@ RUN composer install \
     --prefer-dist; \
     composer clear-cache
 
-ENV SSLKey=".docker/ssl/server.key"
-ENV SSLCert=".docker/ssl/server.crt"
-
-# Dev environment config: MailHog SMTP, SSL Keys and PCOV
-RUN curl -LkSso /usr/bin/mhsendmail 'https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64' && \
+# Install mailhog smtp
+ARG MHSENDMAIL_VERSION=0.2.0
+RUN curl -LkSso /usr/bin/mhsendmail 'https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64' && \
     chmod 0755 /usr/bin/mhsendmail && \
-    echo 'sendmail_path = "/usr/bin/mhsendmail --smtp-addr=mailhog:1025"' >> /usr/local/etc/php/php.ini && \
-    apk update && apk add --no-cache --virtual build-deps ${PHPIZE_DEPS} && \
+    echo 'sendmail_path = "/usr/bin/mhsendmail --smtp-addr=mailhog:1025"' >> /usr/local/etc/php/php.ini;
+
+# Configure PCOV
+RUN apk update && apk add --no-cache --virtual build-deps ${PHPIZE_DEPS} && \
     pecl install pcov && \
     pecl clear-cache && \
     docker-php-ext-enable pcov && \
+    apk del build-deps && \
     echo "error_reporting = E_ALL" >> /usr/local/etc/php/php.ini && \
     echo "display_startup_errors = On" >> /usr/local/etc/php/php.ini && \
     echo "display_errors = On" >> /usr/local/etc/php/php.ini && \
     echo "pcov.directory = /var/www/html/src" >> /usr/local/etc/php/php.ini && \
-    echo "pcov.exclude = /var/www/html/vendor" >> /usr/local/etc/php/php.ini; \
-    apk del build-deps;
+    echo "pcov.exclude = /var/www/html/vendor" >> /usr/local/etc/php/php.ini;
 
+# Configure SSL
+ENV SSLKey=".docker/ssl/server.key"
+ENV SSLCert=".docker/ssl/server.crt"
 COPY . .
 RUN if [ ! -e "$SSLKey" ] && [ ! -e "$SSLCert" ]; then \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
@@ -56,19 +59,9 @@ RUN composer install \
 FROM samhwang/php:7.4-alpine as production
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-ENV SSLKey=".docker/ssl/server.key"
-ENV SSLCert=".docker/ssl/server.crt"
-
 WORKDIR /var/www/html
-
-COPY ./.docker/ssl ./.docker/ssl
-RUN if [ ! -e "$SSLKey" ] && [ ! -e "$SSLCert" ]; then \
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
-    else \
-    cp -r .docker/ssl /etc/ssl; \
-    fi; \
-    rm -rf .docker;
 
 COPY ./public ./public
 COPY ./src ./src
 COPY --from=build /var/www/html/vendor/ ./vendor/
+COPY --from=build /etc/ssl /etc/ssl

--- a/php/.docker/Dockerfile
+++ b/php/.docker/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 WORKDIR /var/www/html
 
 # Install composer dependencies
-COPY --from=composer:1.10.6 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
 COPY composer.json composer.lock ./
 
 RUN composer install \
@@ -14,14 +14,14 @@ RUN composer install \
     --prefer-dist; \
     composer clear-cache
 
-ENV SSLKey=".docker/ssl/server.key"
-ENV SSLCert=".docker/ssl/server.crt"
-
-# Dev environment config: MailHog SMTP, SSL Keys and PCOV
-RUN curl -LkSso /usr/bin/mhsendmail 'https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64' && \
+# Install mailhog smtp
+ARG MHSENDMAIL_VERSION=0.2.0
+RUN curl -LkSso /usr/bin/mhsendmail 'https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64' && \
     chmod 0755 /usr/bin/mhsendmail && \
-    echo 'sendmail_path = "/usr/bin/mhsendmail --smtp-addr=mailhog:1025"' >> /usr/local/etc/php/php.ini && \
-    pecl install pcov && \
+    echo 'sendmail_path = "/usr/bin/mhsendmail --smtp-addr=mailhog:1025"' >> /usr/local/etc/php/php.ini;
+
+# Configure PCOV
+RUN pecl install pcov && \
     pecl clear-cache && \
     docker-php-ext-enable pcov && \
     echo "error_reporting = E_ALL" >> /usr/local/etc/php/php.ini && \
@@ -30,6 +30,9 @@ RUN curl -LkSso /usr/bin/mhsendmail 'https://github.com/mailhog/mhsendmail/relea
     echo "pcov.directory = /var/www/html/src" >> /usr/local/etc/php/php.ini && \
     echo "pcov.exclude = /var/www/html/vendor" >> /usr/local/etc/php/php.ini;
 
+# Configure SSL
+ENV SSLKey=".docker/ssl/server.key"
+ENV SSLCert=".docker/ssl/server.crt"
 COPY . .
 RUN if [ ! -e "$SSLKey" ] && [ ! -e "$SSLCert" ]; then \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
@@ -54,19 +57,9 @@ RUN composer install \
 FROM samhwang/php:7.4 as production
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-ENV SSLKey=".docker/ssl/server.key"
-ENV SSLCert=".docker/ssl/server.crt"
-
 WORKDIR /var/www/html
-
-COPY ./.docker/ssl ./.docker/ssl
-RUN if [ ! -e "$SSLKey" ] && [ ! -e "$SSLCert" ]; then \
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
-    else \
-    cp -r .docker/ssl /etc/ssl; \
-    fi; \
-    rm -rf .docker;
 
 COPY ./public ./public
 COPY ./src ./src
 COPY --from=build /var/www/html/vendor/ ./vendor/
+COPY --from=build /etc/ssl /etc/ssl


### PR DESCRIPTION
- Remove patch version of composer, now using minor versions
- Move installing mailhog, installing and configuring PCOV and
configuring SSL into 3 different steps. This will make the image a bit
larger in size, but will make it easier to build in the future because
of layer caching.
- Remove the need to generate SSH keys in the production image, as it
will copy the SSL image from dev stage. To run this in production,
ideally there will be a real SSL key to use as a volume.
